### PR TITLE
Add option to enable/disable logging.

### DIFF
--- a/app/code/local/Aoe/JsCssTstamp/Model/Package.php
+++ b/app/code/local/Aoe/JsCssTstamp/Model/Package.php
@@ -281,7 +281,9 @@ class Aoe_JsCssTstamp_Model_Package extends Mage_Core_Model_Design_Package {
 		}
 
 		if ($this->addTstampToAssets) {
-			Mage::log('Aoe_JsCssTsamp: ' . $uri);
+		    if (Mage::getStoreConfigFlag('dev/log/aoeJsCssTstampActive')) {
+		        Mage::log('Aoe_JsCssTstamp: ' . $uri);
+		    }
 			$matches = array();
 			if (preg_match('/(.*)\.(gif|png|jpg)$/i', $uri, $matches)) {
 				$uri = $matches[1] . '.' . $this->getVersionKey() . '.' . $matches[2];

--- a/app/code/local/Aoe/JsCssTstamp/etc/config.xml
+++ b/app/code/local/Aoe/JsCssTstamp/etc/config.xml
@@ -67,6 +67,9 @@
 				<storage>file</storage>
 				<addTstampToAssets>0</addTstampToAssets>
 			</css>
+			<log>
+				<aoeJsCssTstampActive>1</aoeJsCssTstampActive>
+			</log>
 		</dev>
 	</default>
 

--- a/app/code/local/Aoe/JsCssTstamp/etc/system.xml
+++ b/app/code/local/Aoe/JsCssTstamp/etc/system.xml
@@ -78,6 +78,19 @@
 						</addTstampToAssets>
 					</fields>
 				</css>
+				<log>
+					<fields>
+						<aoeJsCssTstampActive translate="label">
+							<label>Log Aoe_JsCssTstamp messages</label>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+							<sort_order>100</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</aoeJsCssTstampActive>
+					</fields>
+				</log>
 			</groups>
 		</dev>
 	</sections>


### PR DESCRIPTION
Aoe_JsCssTstamp logs URIs of .png/.gif/.jpg files in case that timestamps are added. This feature adds lines to our log which we don't need.

Therefore I added the option to disable logging for this extension. By default logging stays enabled so the default behaviour is unchanged.

I didn't bump up the version number in case you want to handle this yourself.
