### PR TITLE
adding Nginx rewrite rules

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,6 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule .* ../get.php [L]
 
 # If you enable the Add timestamps to asset files feature, also add these lines to your .htaccess file
-RewriteCond %{REQUEST_URI} ^/skin/
 RewriteRule (.*)\.(\d{10})\.(gif|png|jpg)$ $1.$3 [L,NC]
 
 If you use NGINX, add the following lines to your nginx config within the server block for your site 
@@ -32,5 +31,5 @@ location @handlercss {
 
 # If you enable the Add timestamps to asset files feature, also add these lines to your nginx config file
 # they should NOT be added to any particular location block.
-rewrite "^/skin/(.*)\.(\d{10})\.(gif|png|jpg)$" /skin/$1.$3 last;
+rewrite "^/(.*)\.(\d{10})\.(gif|png|jpg)$" /$1.$3 last;
 


### PR DESCRIPTION
I've added nginx rewrite rules that work with this module for both database storage mode and also the adding timestamps to assets mode

this is tested to work on an nginx install, it then generates the files in the right locations and then try_files takes over and serves direct from disc for subsequent requests for maximum performance until cache is cleared at which point it will fall back the the rewrite

also these rules are "performance safe" if you are using filesystem to store files as try_files will always prefer a physical file on the server over going to php/database so can be left installed if you are using filesystem as cache location
