### PR TITLE
Added support for parent::__construct() in Aoe_JsCssTstamp_Model_Package...

### DIFF
--- a/app/code/local/Aoe/JsCssTstamp/Model/Package.php
+++ b/app/code/local/Aoe/JsCssTstamp/Model/Package.php
@@ -150,7 +150,10 @@ class Aoe_JsCssTstamp_Model_Package extends Mage_Core_Model_Design_Package {
 	 * @return string
 	 */
 	public function beforeMergeJs($file, $contents) {
-		$contents = "\n\n/* FILE: " . basename($file) . " */\n" . $contents;
+
+		// In some cases, browsers will choke if the component files don't end
+		// with a statement ending, so we'll force one here to be safe.
+		$contents = ";\n\n/* FILE: " . basename($file) . " */\n" . $contents;
 		return $contents;
 	}
 
@@ -161,12 +164,9 @@ class Aoe_JsCssTstamp_Model_Package extends Mage_Core_Model_Design_Package {
 	 * @param string $contents
 	 * @return string
 	 */
-	public function beforeMergeJs($file, $contents) {
-
-		// In some cases, browsers will choke if the component files don't end
-		// with a statement ending, so we'll force one here to be safe.
-		$contents = ";\n\n/* FILE: " . basename($file) . " */\n" . $contents;
-		return $contents;
+	public function beforeMergeCss($file, $contents) {
+		$contents = "\n\n/* FILE: " . basename($file) . " */\n" . $contents;
+		return parent::beforeMergeCss($file, $contents);
 	}
 
 	/**


### PR DESCRIPTION
... now that it exists in Magento CE 1.9.0.1 and EE 1.14.0.1.

In the newest versions of Magento, Mage_Core_Model_Design_Package has a __construct() method, so we need to call it in order for the rewrite to correctly execute the functionality in the parent.

Now also includes a change to prepend a semicolon to each JS file in order to ensure browsers don't hiccup on the final concatenated file.
